### PR TITLE
Morphdom-permanent task

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -9,7 +9,11 @@ document.addEventListener("turbo:before-render", (event) => {
   prevPath = window.location.pathname;
   event.detail.render = async (prevEl, newEl) => {
     await new Promise((resolve) => setTimeout(() => resolve(), 0));
-    morphdom(prevEl, newEl);
+    morphdom(prevEl, newEl, {
+      onBeforeElUpdated: function(fromEl, toEl) {
+        return !(fromEl.hasAttribute("data-turbo-morphdom-permanent") || fromEl.isEqualNode(toEl))
+      }
+    });
   };
 
   if (document.startViewTransition) {
@@ -37,6 +41,9 @@ document.addEventListener("turbo:before-frame-render", (event) => {
 
     morphdom(currentElement, newElement, {
       childrenOnly: true,
+      onBeforeElUpdated: function(fromEl, toEl) {
+        return !(fromEl.hasAttribute("data-turbo-morphdom-permanent") || fromEl.isEqualNode(toEl))
+      }
     });
   };
 

--- a/app/views/albums/_aside.html.erb
+++ b/app/views/albums/_aside.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (album: nil) -%>
-<%= turbo_frame_tag :aside, class: "aside", target: "_top", data: {"turbo-permanent" => true}, "transition-name" => "aside" do %>
+<%= turbo_frame_tag :aside, class: "aside", target: "_top", data: {"turbo-morphdom-permanent" => true}, "transition-name" => "aside" do %>
   <% next unless album %>
   <div transition-id="<%= album.id %>">
     <div class="album-info">

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -25,7 +25,7 @@
     <%- if current_user -%>
       <span class="nav--username"><%= User::PREFIX + current_user.username %></span>
       <%= button_to "Sign out", sign_out_path, method: :delete, class: "nav--btn--outlined ml-2" %>
-    <%- else- %>
+    <%- else -%>
       <%= link_to "Sign up", sign_up_path, class: "nav--btn--outlined" %>
       <%= link_to "Log in", sign_in_path, class: "nav--btn ml-2" %>
     <%- end -%>

--- a/app/views/shared/_player.html.erb
+++ b/app/views/shared/_player.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (track:, station: nil) -%>
-<div class="player" id="<%= dom_id(station || track, "player_#{track.id}") %>" data-turbo-permanent>
+<div class="player" id="<%= dom_id(station || track, "player_#{track.id}") %>" data-turbo-morphdom-permanent>
   <% if track %>
     <div class="player--timeline">
       <div class="player--timeline-progress" style="width:11%;"></div>


### PR DESCRIPTION
**Задание**

Необходимо перенести логику перманентных элементов из Turbo в morphdom и сделать так, чтобы элементы остались в DOM-дереве, если нет необходимости их перерисовывать.

**Критерии выполнения**

- Прогресс-бар плеера не прерывается при навигации по приложению
- Прогресс-бар стартует заново при смене трека в плеера